### PR TITLE
@frappe.whitelist() on read_image

### DIFF
--- a/erpnext_ocr/erpnext_ocr/doctype/ocr_read/ocr_read.py
+++ b/erpnext_ocr/erpnext_ocr/doctype/ocr_read/ocr_read.py
@@ -50,6 +50,7 @@ class OCRRead(Document):
         self.read_time = None
         super(OCRRead, self).__init__(*args, **kwargs)
 
+    @frappe.whitelist()
     def read_image(self):
         return read_ocr(self)
 


### PR DESCRIPTION
Handle the error:
![Captura de pantalla de 2024-02-05 17-48-21](https://github.com/phamos-eu/erpnext_ocr/assets/6966715/9e9ea172-9841-40ad-9441-e76d24f096da)


```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 95, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 47, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 85, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1620, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/handler.py", line 311, in run_doc_method
    is_whitelisted(fn)
  File "apps/frappe/frappe/__init__.py", line 787, in is_whitelisted
    throw(msg, PermissionError, title="Method Not Allowed")
  File "apps/frappe/frappe/__init__.py", line 540, in throw
    msgprint(
  File "apps/frappe/frappe/__init__.py", line 508, in msgprint
    _raise_exception()
  File "apps/frappe/frappe/__init__.py", line 454, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.PermissionError: <details><summary>You are not permitted to access this resource.</summary>Function <strong>erpnext_ocr.erpnext_ocr.doctype.ocr_read.ocr_read.read_image</strong> is not whitelisted.</details>
```